### PR TITLE
Remove method is deprecated

### DIFF
--- a/remaster.py
+++ b/remaster.py
@@ -7,6 +7,6 @@ client = MongoClient()
 db = client.minor
 boys = db.boys
 reqdb = db.reqdb
-boys.remove()
-reqdb.remove()
+boys.delete_many({})
+reqdb.delete_many({})
 pickle.dump(af.createSearchTree(),open('tree.pickle','wb'))


### PR DESCRIPTION
Change purpose:
- remove is now deprecated so i use `delete_many({})` instead